### PR TITLE
[Improvement]Improve-DorisSource's-validation-for-DorisReadOptions

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/DorisSourceBuilder.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/DorisSourceBuilder.java
@@ -63,6 +63,9 @@ public class DorisSourceBuilder<OUT> {
     }
 
     public DorisSource<OUT> build() {
+        if(dorisReadOptions == null) {
+            dorisReadOptions = DorisReadOptions.builder().build();
+        }
         return new DorisSource<>(options, readOptions, boundedness, deserializer);
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: 65 build()

## Problem Summary:
There is no null value test for dorisReadOptions in DorisSource builder

## changes:
Maintain the same standards as DorisSink builder